### PR TITLE
Incompatibilidade após atualização do enumitem

### DIFF
--- a/ucsmonograph.dtx
+++ b/ucsmonograph.dtx
@@ -56,7 +56,7 @@
 %</driver>
 %\fi
 
-% \CheckSum{643}
+% \CheckSum{648}
 
 % \CharacterTable
 %  {Upper-case	\A\B\C\D\E\F\G\H\I\J\K\L\M\N\O\P\Q\R\S\T\U\V\W\X\Y\Z
@@ -734,7 +734,9 @@
 %\changes{v1.1.2}{2018/09/28}{Ajustar parâmetros de acordo com o padrão da UCS}
 % Configuração das listas para atender ao padrão da UCS.
 %    \begin{macrocode}
-\setlist[enumerate,1]{labelindent=\parindent,leftmargin=0.6cm+\parindent,nosep,label=\alph*)}
+\newlength\@enumerateindent
+\setlength\@enumerateindent{\parindent+0.6cm}
+\setlist[enumerate,1]{labelindent=\parindent,leftmargin=\@enumerateindent,nosep,label=\alph*)}
 %    \end{macrocode}
 %\end{macro}
 %

--- a/ucsmonograph.dtx
+++ b/ucsmonograph.dtx
@@ -33,7 +33,7 @@
 %<class>\NeedsTeXFormat{LaTeX2e}
 %<class>\ProvidesClass{ucsmonograph}
 %<*class>
-	[2018/11/22 v1.2.0 Padrao de monografias da UCS]
+	[2018/12/10 v1.2.1 Padrao de monografias da UCS]
 %</class>
 %
 %<*driver>
@@ -732,6 +732,7 @@
 %
 %\begin{macro}{enumerate}
 %\changes{v1.1.2}{2018/09/28}{Ajustar parâmetros de acordo com o padrão da UCS}
+%\changes{v1.2.1}{2018/12/10}{Criar um length para configurar os enumerates}
 % Configuração das listas para atender ao padrão da UCS.
 %    \begin{macrocode}
 \newlength\@enumerateindent


### PR DESCRIPTION
Corrigida a incompatibilidade após a atualização do pacote enumitem com a criação do length `\@enumerateindent`.